### PR TITLE
Update KeyboardAvoidingContainer.tsx

### DIFF
--- a/src/KeyboardAvoidingContainer.tsx
+++ b/src/KeyboardAvoidingContainer.tsx
@@ -218,7 +218,7 @@ export function useKeyboardAvoidingContainerProps<
         if (keyboardLayoutRef.current) return
 
         const {endCoordinates: newKeyboardLayout} = event
-        const newFocusedTextInputNodeHandle = NativeTextInput.State.currentlyFocusedField()
+        const newFocusedTextInputNodeHandle = NativeTextInput.State.currentlyFocusedInput()
         const newStickyFooterNodeHandle = findNodeHandle(
           stickyFooterRef.current,
         )


### PR DESCRIPTION
Fix a error about
```
 ERROR  currentlyFocusedField is deprecated and will be removed in a future release. Use currentlyFocusedInput
```